### PR TITLE
Externalized SSL error handling (issue #193)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,16 @@ Connect using SSL:
     client->setClientId("clientId");
     client->setUsername("user");
     client->setPassword("password");
+    // Optionally, set ssl errors you want to ignore. Be careful, because this may weaken security.
+    // See QSslSocket::ignoreSslErrors(const QList<QSslError> &) for more information.
+    client->ignoreSslErrors(<list of expected ssl errors>)
     client->connectToHost();
+    // Here's another option to suppress SSL errors (again, be careful)
+    QObject::connect(client, &QMQTT::Client::sslErrors, [&](const QList<QSslError> &errors) {
+        // Investigate the errors here, if you find no serious problems, call ignoreSslErrors()
+        // to continue connecting.
+        client->ignoreSslErrors();
+    });
 
 Connect using WebSockets:
 

--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -374,3 +374,25 @@ void QMQTT::Client::onNetworkError(QAbstractSocket::SocketError error)
     Q_D(Client);
     d->onNetworkError(error);
 }
+
+#ifndef QT_NO_SSL
+void QMQTT::Client::onSslErrors(const QList<QSslError>& errors)
+{
+    Q_D(Client);
+    d->onSslErrors(errors);
+}
+#endif // QT_NO_SSL
+
+#ifndef QT_NO_SSL
+void QMQTT::Client::ignoreSslErrors()
+{
+    Q_D(Client);
+    d->ignoreSslErrors();
+}
+
+void QMQTT::Client::ignoreSslErrors(const QList<QSslError>& errors)
+{
+    Q_D(Client);
+    d->ignoreSslErrors(errors);
+}
+#endif // QT_NO_SSL

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -40,6 +40,7 @@
 #include <QByteArray>
 #include <QAbstractSocket>
 #include <QScopedPointer>
+#include <QList>
 
 #ifdef QT_WEBSOCKETS_LIB
 #include <QWebSocket>
@@ -47,6 +48,7 @@
 
 #ifndef QT_NO_SSL
 QT_FORWARD_DECLARE_CLASS(QSslConfiguration)
+QT_FORWARD_DECLARE_CLASS(QSslError)
 #endif // QT_NO_SSL
 
 namespace QMQTT {
@@ -145,7 +147,7 @@ public:
     // This function is provided for backward compatibility with older versions of QMQTT.
     // If the ssl parameter is true, this function will load a private key ('cert.key') and a local
     // certificate ('cert.crt') from the current working directory. It will also set PeerVerifyMode
-    // to None. This may not be the safest way to set up a SSL connection.
+    // to None. This may not be the safest way to set up an SSL connection.
     Client(const QString& hostName,
            const quint16 port,
            const bool ssl,
@@ -222,6 +224,11 @@ public slots:
 
     quint16 publish(const QMQTT::Message& message);
 
+#ifndef QT_NO_SSL
+    void ignoreSslErrors();
+    void ignoreSslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
+
 signals:
     void connected();
     void disconnected();
@@ -232,6 +239,9 @@ signals:
     void published(const QMQTT::Message& message, quint16 msgid = 0);
     void received(const QMQTT::Message& message);
     void pingresp();
+#ifndef QT_NO_SSL
+    void sslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
 
 protected slots:
     void onNetworkConnected();
@@ -240,6 +250,9 @@ protected slots:
     void onTimerPingReq();
     void onPingTimeout();
     void onNetworkError(QAbstractSocket::SocketError error);
+#ifndef QT_NO_SSL
+    void onSslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
 
 protected:
     QScopedPointer<ClientPrivate> d_ptr;

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -85,6 +85,9 @@ public:
 #ifdef QT_WEBSOCKETS_LIB
     QWebSocketProtocol::Version _webSocketVersion;
 #endif // QT_WEBSOCKETS_LIB
+#ifndef QT_NO_SSL
+    bool _ignoreSelfSigned;
+#endif // QT_NO_SSL
     quint16 _gmid;
     MQTTVersion _version;
     QString _clientId;
@@ -163,6 +166,11 @@ public:
     bool willRetain() const;
     QByteArray willMessage() const;
     void onNetworkError(QAbstractSocket::SocketError error);
+#ifndef QT_NO_SSL
+    void ignoreSslErrors();
+    void ignoreSslErrors(const QList<QSslError>& errors);
+    void onSslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
 
     Q_DECLARE_PUBLIC(Client)
 };

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -57,16 +57,17 @@ QMQTT::Network::Network(QObject* parent)
 }
 
 #ifndef QT_NO_SSL
-QMQTT::Network::Network(const QSslConfiguration &config, bool ignoreSelfSigned, QObject *parent)
+QMQTT::Network::Network(const QSslConfiguration& config, QObject *parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_SSL_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::SslSocket(config, ignoreSelfSigned))
+    , _socket(new QMQTT::SslSocket(config))
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
 {
     initialize();
+    connect(_socket, &QMQTT::SslSocket::sslErrors, this, &QMQTT::Network::sslErrors);
 }
 #endif // QT_NO_SSL
 
@@ -75,13 +76,12 @@ QMQTT::Network::Network(const QSslConfiguration &config, bool ignoreSelfSigned, 
 QMQTT::Network::Network(const QString& origin,
                         QWebSocketProtocol::Version version,
                         const QSslConfiguration* sslConfig,
-                        bool ignoreSelfSigned,
                         QObject* parent)
     : NetworkInterface(parent)
     , _port(DEFAULT_SSL_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::WebSocket(origin, version, sslConfig, ignoreSelfSigned))
+    , _socket(new QMQTT::WebSocket(origin, version, sslConfig))
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
 {
@@ -271,3 +271,15 @@ void QMQTT::Network::onDisconnected()
         _autoReconnectTimer->start();
     }
 }
+
+#ifndef QT_NO_SSL
+void QMQTT::Network::ignoreSslErrors(const QList<QSslError>& errors)
+{
+    _socket->ignoreSslErrors(errors);
+}
+
+void QMQTT::Network::ignoreSslErrors()
+{
+    _socket->ignoreSslErrors();
+}
+#endif // QT_NO_SSL

--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -60,14 +60,13 @@ class Network : public NetworkInterface
 public:
     Network(QObject* parent = NULL);
 #ifndef QT_NO_SSL
-    Network(const QSslConfiguration& config, bool ignoreSelfSigned, QObject* parent = NULL);
+    Network(const QSslConfiguration& config, QObject* parent = NULL);
 #endif // QT_NO_SSL
 #ifdef QT_WEBSOCKETS_LIB
 #ifndef QT_NO_SSL
     Network(const QString& origin,
             QWebSocketProtocol::Version version,
             const QSslConfiguration* sslConfig,
-            bool ignoreSelfSigned,
             QObject* parent = NULL);
 #endif // QT_NO_SSL
     Network(const QString& origin,
@@ -85,11 +84,17 @@ public:
     QAbstractSocket::SocketState state() const;
     int autoReconnectInterval() const;
     void setAutoReconnectInterval(const int autoReconnectInterval);
+#ifndef QT_NO_SSL
+    void ignoreSslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
 
 public slots:
     void connectToHost(const QHostAddress& host, const quint16 port);
     void connectToHost(const QString& hostName, const quint16 port);
     void disconnectFromHost();
+#ifndef QT_NO_SSL
+    void ignoreSslErrors();
+#endif // QT_NO_SSL
 
 protected slots:
     void onSocketError(QAbstractSocket::SocketError socketError);

--- a/src/mqtt/qmqtt_networkinterface.h
+++ b/src/mqtt/qmqtt_networkinterface.h
@@ -38,6 +38,11 @@
 #include <QAbstractSocket>
 #include <QHostAddress>
 #include <QString>
+#include <QList>
+
+#ifndef QT_NO_SSL
+QT_FORWARD_DECLARE_CLASS(QSslError)
+#endif // QT_NO_SSL
 
 namespace QMQTT {
 
@@ -57,17 +62,26 @@ public:
     virtual int autoReconnectInterval() const = 0;
     virtual void setAutoReconnectInterval(const int autoReconnectInterval) = 0;
     virtual QAbstractSocket::SocketState state() const = 0;
+#ifndef QT_NO_SSL
+    virtual void ignoreSslErrors(const QList<QSslError>& errors) = 0;
+#endif // QT_NO_SSL
 
 public slots:
     virtual void connectToHost(const QHostAddress& host, const quint16 port) = 0;
     virtual void connectToHost(const QString& hostName, const quint16 port) = 0;
     virtual void disconnectFromHost() = 0;
+#ifndef QT_NO_SSL
+    virtual void ignoreSslErrors() = 0;
+#endif // QT_NO_SSL
 
 signals:
     void connected();
     void disconnected();
     void received(const QMQTT::Frame& frame);
     void error(QAbstractSocket::SocketError error);
+#ifndef QT_NO_SSL
+    void sslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
 };
 
 } // namespace QMQTT

--- a/src/mqtt/qmqtt_socketinterface.h
+++ b/src/mqtt/qmqtt_socketinterface.h
@@ -38,6 +38,11 @@
 #include <QHostAddress>
 #include <QString>
 #include <QAbstractSocket>
+#include <QList>
+
+#ifndef QT_NO_SSL
+QT_FORWARD_DECLARE_CLASS(QSslError)
+#endif // QT_NO_SSL
 
 QT_FORWARD_DECLARE_CLASS(QIODevice)
 
@@ -49,19 +54,26 @@ class Q_MQTT_EXPORT SocketInterface : public QObject
     Q_OBJECT
 public:
     explicit SocketInterface(QObject* parent = NULL) : QObject(parent) {}
-    virtual	~SocketInterface() {}
+    virtual ~SocketInterface() {}
 
-    virtual QIODevice *ioDevice() = 0;
+    virtual QIODevice* ioDevice() = 0;
     virtual void connectToHost(const QHostAddress& address, quint16 port) = 0;
     virtual void connectToHost(const QString& hostName, quint16 port) = 0;
     virtual void disconnectFromHost() = 0;
     virtual QAbstractSocket::SocketState state() const = 0;
     virtual QAbstractSocket::SocketError error() const = 0;
+#ifndef QT_NO_SSL
+    virtual void ignoreSslErrors(const QList<QSslError>& errors) {}
+    virtual void ignoreSslErrors() {}
+#endif // QT_NO_SSL
 
 signals:
     void connected();
     void disconnected();
     void error(QAbstractSocket::SocketError socketError);
+#ifndef QT_NO_SSL
+    void sslErrors(const QList<QSslError>& errors);
+#endif // QT_NO_SSL
 };
 
 }

--- a/src/mqtt/qmqtt_ssl_socket.cpp
+++ b/src/mqtt/qmqtt_ssl_socket.cpp
@@ -38,10 +38,9 @@
 #include <QSslSocket>
 #include <QSslError>
 
-QMQTT::SslSocket::SslSocket(const QSslConfiguration &config, bool ignoreSelfSigned, QObject* parent)
+QMQTT::SslSocket::SslSocket(const QSslConfiguration& config, QObject* parent)
     : SocketInterface(parent)
     , _socket(new QSslSocket(this))
-    , _ignoreSelfSigned(ignoreSelfSigned)
 {
     _socket->setSslConfiguration(config);
     connect(_socket.data(), &QSslSocket::encrypted,    this, &SocketInterface::connected);
@@ -90,18 +89,13 @@ QAbstractSocket::SocketError QMQTT::SslSocket::error() const
     return _socket->error();
 }
 
-void QMQTT::SslSocket::sslErrors(const QList<QSslError> &errors)
+void QMQTT::SslSocket::ignoreSslErrors(const QList<QSslError>& errors)
 {
-    if (!_ignoreSelfSigned)
-        return;
-    foreach (QSslError error, errors)
-    {
-        if (error.error() != QSslError::SelfSignedCertificate &&
-            error.error() != QSslError::SelfSignedCertificateInChain)
-        {
-            return;
-        }
-    }
+    _socket->ignoreSslErrors(errors);
+}
+
+void QMQTT::SslSocket::ignoreSslErrors()
+{
     _socket->ignoreSslErrors();
 }
 

--- a/src/mqtt/qmqtt_ssl_socket_p.h
+++ b/src/mqtt/qmqtt_ssl_socket_p.h
@@ -54,7 +54,7 @@ class SslSocket : public SocketInterface
 {
     Q_OBJECT
 public:
-    explicit SslSocket(const QSslConfiguration &config, bool ignoreSelfSigned, QObject* parent = NULL);
+    explicit SslSocket(const QSslConfiguration& config, QObject* parent = NULL);
     virtual ~SslSocket();
 
     virtual QIODevice *ioDevice();
@@ -63,13 +63,11 @@ public:
     void disconnectFromHost();
     QAbstractSocket::SocketState state() const;
     QAbstractSocket::SocketError error() const;
-
-protected slots:
-    void sslErrors(const QList<QSslError> &errors);
+    void ignoreSslErrors(const QList<QSslError>& errors);
+    void ignoreSslErrors();
 
 protected:
     QScopedPointer<QSslSocket> _socket;
-    bool _ignoreSelfSigned;
 };
 
 }

--- a/src/mqtt/qmqtt_websocket.cpp
+++ b/src/mqtt/qmqtt_websocket.cpp
@@ -10,12 +10,10 @@
 QMQTT::WebSocket::WebSocket(const QString& origin,
                             QWebSocketProtocol::Version version,
                             const QSslConfiguration* sslConfig,
-                            bool ignoreSelfSigned,
                             QObject* parent)
     : SocketInterface(parent)
     , _socket(new QWebSocket(origin, version, this))
     , _ioDevice(new WebSocketIODevice(_socket, this))
-    , _ignoreSelfSigned(ignoreSelfSigned)
 {
     initialize();
     if (sslConfig != NULL)
@@ -80,18 +78,13 @@ QAbstractSocket::SocketError QMQTT::WebSocket::error() const
 }
 
 #ifndef QT_NO_SSL
-void QMQTT::WebSocket::sslErrors(const QList<QSslError> &errors)
+void QMQTT::WebSocket::ignoreSslErrors(const QList<QSslError>& errors)
 {
-    if (!_ignoreSelfSigned)
-        return;
-    foreach (QSslError error, errors)
-    {
-        if (error.error() != QSslError::SelfSignedCertificate &&
-            error.error() != QSslError::SelfSignedCertificateInChain)
-        {
-            return;
-        }
-    }
+    _socket->ignoreSslErrors(errors);
+}
+
+void QMQTT::WebSocket::ignoreSslErrors()
+{
     _socket->ignoreSslErrors();
 }
 #endif // QT_NO_SSL

--- a/src/mqtt/qmqtt_websocket_p.h
+++ b/src/mqtt/qmqtt_websocket_p.h
@@ -61,7 +61,6 @@ public:
     WebSocket(const QString& origin,
               QWebSocketProtocol::Version version,
               const QSslConfiguration* sslConfig,
-              bool ignoreSelfSigned,
               QObject* parent = NULL);
 #endif // QT_NO_SSL
 
@@ -81,10 +80,9 @@ public:
     void disconnectFromHost();
     QAbstractSocket::SocketState state() const;
     QAbstractSocket::SocketError error() const;
-
-private slots:
 #ifndef QT_NO_SSL
-    void sslErrors(const QList<QSslError> &errors);
+    void ignoreSslErrors(const QList<QSslError>& errors);
+    void ignoreSslErrors();
 #endif // QT_NO_SSL
 
 private:
@@ -92,9 +90,6 @@ private:
 
     QWebSocket *_socket;
     WebSocketIODevice *_ioDevice;
-#ifndef QT_NO_SSL
-    bool _ignoreSelfSigned;
-#endif // QT_NO_SSL
 };
 
 }

--- a/tests/gtest/tests/networkmock.h
+++ b/tests/gtest/tests/networkmock.h
@@ -3,6 +3,9 @@
 
 #include <qmqtt_networkinterface.h>
 #include <gmock/gmock.h>
+#ifndef QT_NO_SSL
+#include <QSslSocket>
+#endif // QT_NO_SSL
 
 class NetworkMock : public QMQTT::NetworkInterface
 {
@@ -16,8 +19,11 @@ public:
     MOCK_CONST_METHOD0(state, QAbstractSocket::SocketState());
     MOCK_METHOD2(connectToHost, void(const QHostAddress&, const quint16));
     MOCK_METHOD2(connectToHost, void(const QString&, const quint16));
-    MOCK_METHOD0(disconnectFromHost, void());    
+    MOCK_METHOD0(disconnectFromHost, void());
+#ifndef QT_NO_SSL
+    MOCK_METHOD1(ignoreSslErrors, void(const QList<QSslError>& errors));
+    MOCK_METHOD0(ignoreSslErrors, void());
+#endif // QT_NO_SSL
 };
 
 #endif // NETWORK_MOCK_H
-


### PR DESCRIPTION
See README.md for an example.

* Created a new signal `sslErrors` to `QMQTT::Client`, and added code to make sure this signal is emitted whenever an internal `QSslSocket` or `QWebSocket` instances emits the same signal.
* Create `ignoreSslError` functions in `QMQTT::Client` and added code to call the those function on an internal `QSslSocket` or `QWebSocket` instances.