### PR TITLE
Build system: check if QtWebSockets is available

### DIFF
--- a/src/mqtt/qmqtt.pro
+++ b/src/mqtt/qmqtt.pro
@@ -1,6 +1,6 @@
 TARGET = QtQmqtt
 QT = core network
-QMQTT_WEBSOCKETS: QT += websockets
+qtHaveModule(websockets): QMQTT_WEBSOCKETS: QT += websockets
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 


### PR DESCRIPTION
Qt Creator's .pro file parser evaluates:

    QMQTT_WEBSOCKETS: QT += websockets

regardless of whether QMQTT_WEBSOCKETS is defined or not.

When using a trimmed down Qt build/installation without QtWebSockets,
this leads to an error which is visible in the General Messages pane:

   Project ERROR: Unknown module(s) in QT: websockets

As a nasty side-effect, when QMQTT is included as part of a larger
project tree, the run targets of that project will not show up as
appropriate in Qt Creator. Checking whether the QtWebSocket module
actually exists, solves the problem.