### PR TITLE
fix-203

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ mqtt client for Qt
 
 **Please compile the library with Qt >= 5.3 version. On Windows you need to specify `CONFIG += NO_UNIT_TESTS`, since gtest is not supported.**
 
+SSL is enabled by default, if the version of OpenSSL < 1.0.2, SSL may not be supported. 
+
+Disable the SSL in CMakeLists.txt (cmake):
+
+    option( ${PROJECT_NAME}_SSL "Enable SSL support for MQTT" OFF )
+
+Disable the SSL with src/mqtt/qmqtt.pro (qmake):
+
+    CONFIG+=QMQTT_NO_SSL
+
 To add websocket support, compile the library with Qt >= 5.7, and specify 'CONFIG += QMQTT_WEBSOCKETS'.
 This also works when compiling qmqtt for WebAssembly.
 

--- a/src/mqtt/qmqtt.pro
+++ b/src/mqtt/qmqtt.pro
@@ -4,6 +4,8 @@ qtHaveModule(websockets): QMQTT_WEBSOCKETS: QT += websockets
 
 DEFINES += QT_NO_CAST_TO_ASCII QT_NO_CAST_FROM_ASCII
 
+# CONFIG += QMQTT_NO_SSL
+
 HEADERS += \
     $$PWD/qmqtt_global.h \
     $$PWD/qmqtt.h


### PR DESCRIPTION
Some usage help has been added. 
When the version of OpenSSL is low, the compilation of the ssl part will fail.