### PR TITLE
Expose enums to the Qt meta-object system

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -51,7 +51,14 @@
 QT_FORWARD_DECLARE_CLASS(QSslError)
 #endif // QT_NO_SSL
 
+#ifndef Q_ENUM_NS
+#define Q_ENUM_NS(x)
+#endif // Q_ENUM_NS
+
 namespace QMQTT {
+#if (QT_VERSION >= QT_VERSION_CHECK(5, 8, 0))
+Q_MQTT_EXPORT Q_NAMESPACE
+#endif
 
 static const quint8 LIBRARY_VERSION_MAJOR = 0;
 static const quint8 LIBRARY_VERSION_MINOR = 3;
@@ -63,6 +70,7 @@ enum MQTTVersion
     V3_1_0 = 3,
     V3_1_1 = 4
 };
+Q_ENUM_NS(MQTTVersion)
 
 enum ConnectionState
 {
@@ -71,6 +79,7 @@ enum ConnectionState
     STATE_CONNECTED,
     STATE_DISCONNECTED
 };
+Q_ENUM_NS(ConnectionState)
 
 enum ClientError
 {
@@ -105,6 +114,7 @@ enum ClientError
     MqttNotAuthorizedError,
     MqttNoPingResponse
 };
+Q_ENUM_NS(ClientError)
 
 class ClientPrivate;
 class Message;


### PR DESCRIPTION
This allows e.g. conversions between enum values and key names:

    QMetaEnum metaEnum = QMetaEnum::fromType<QMQTT::ClientError>();
    qDebug() << metaEnum.keyToValue("SocketTimeoutError"); // "6"

Furthermore, this lets QDebug print out descriptive names instead of
plain int values:

    qDebug() << QMQTT::STATE_CONNECTING; // "1" vs. "QMQTT::STATE_CONNECTING"

NOTE: Q_NAMESPACE & Q_ENUM_NS were introduced in Qt 5.8.