### PR TITLE
Fix warnings about deprecated QAbstractSocket::error signals in Qt 5.…

### DIFF
--- a/src/mqtt/qmqtt_socket.cpp
+++ b/src/mqtt/qmqtt_socket.cpp
@@ -41,7 +41,11 @@ QMQTT::Socket::Socket(QObject* parent)
     connect(_socket.data(), &QTcpSocket::connected,    this, &SocketInterface::connected);
     connect(_socket.data(), &QTcpSocket::disconnected, this, &SocketInterface::disconnected);
     connect(_socket.data(),
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+            static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::errorOccurred),
+#else
             static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::error),
+#endif
             this,
             static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
 }

--- a/src/mqtt/qmqtt_ssl_socket.cpp
+++ b/src/mqtt/qmqtt_ssl_socket.cpp
@@ -46,7 +46,11 @@ QMQTT::SslSocket::SslSocket(const QSslConfiguration& config, QObject* parent)
     connect(_socket.data(), &QSslSocket::encrypted,    this, &SocketInterface::connected);
     connect(_socket.data(), &QSslSocket::disconnected, this, &SocketInterface::disconnected);
     connect(_socket.data(),
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+            static_cast<void (QSslSocket::*)(QAbstractSocket::SocketError)>(&QSslSocket::errorOccurred),
+#else
             static_cast<void (QSslSocket::*)(QAbstractSocket::SocketError)>(&QSslSocket::error),
+#endif
             this,
             static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
     connect(_socket.data(),


### PR DESCRIPTION
- Use compiler switch to either use error or the suggested, newer errorOcurred signal