### PR TITLE
Fixed version descrepancy between qmake and cmake builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.9)
 
-project( qmqtt VERSION 0.3.1 ) # version from src/mqtt/qmqtt_client.h
+project( qmqtt VERSION 1.0.0 )
 
 include( GNUInstallDirs ) # needed to define vars used in install() directives.
 


### PR DESCRIPTION
All builds now compile to version 1.0.0

For future changes the version numbers can be found here:

cmake: <repo root>/CMakeLists.txt (in the project command)
qmake: <repo root>/.qmake.conf
qbs:   <repo root>/src/mqtt/qmqtt.qbs (Project.version)