### PR TITLE
Add *.pri file for projects that don't need/want to use QMQTT as an external library

### DIFF
--- a/qmqtt.pri
+++ b/qmqtt.pri
@@ -1,5 +1,19 @@
+#
+# Add the source folder to the include directories to be searched while
+# compiling a project, this allows developers to write "#include <qmqtt.h>" in
+# their respective projects.
+#
 INCLUDEPATH += $$PWD/src/mqtt
 
+#
+# Do not add DLL import/export symbols as we are compiling QMQTT source code
+# directly with the source code of the project that includes this file.
+#
+DEFINES += MQTT_PROJECT_INCLUDE_SRC
+
+#
+# Add header files
+#
 HEADERS += \
     $$PWD/src/mqtt/qmqtt.h \
     $$PWD/src/mqtt/qmqtt_client.h \
@@ -19,6 +33,9 @@ HEADERS += \
     $$PWD/src/mqtt/qmqtt_timerinterface.h \
     $$PWD/src/mqtt/qmqtt_ssl_socket_p.h
 
+#
+# Add source files
+#
 SOURCES += \
     $$PWD/src/mqtt/qmqtt_client.cpp \
     $$PWD/src/mqtt/qmqtt_client_p.cpp \
@@ -31,6 +48,9 @@ SOURCES += \
     $$PWD/src/mqtt/qmqtt_timer.cpp \
     $$PWD/src/mqtt/qmqtt_ssl_socket.cpp
 
+#
+# Add support for websockets
+#
 QMQTT_WEBSOCKETS {
     PRIVATE_HEADERS += \
         $$PWD/src/mqtt/qmqtt_websocket_p.h \

--- a/qmqtt.pri
+++ b/qmqtt.pri
@@ -1,0 +1,42 @@
+INCLUDEPATH += $$PWD/src/mqtt
+
+HEADERS += \
+    $$PWD/src/mqtt/qmqtt.h \
+    $$PWD/src/mqtt/qmqtt_client.h \
+    $$PWD/src/mqtt/qmqtt_client_p.h \
+    $$PWD/src/mqtt/qmqtt_frame.h \
+    $$PWD/src/mqtt/qmqtt_global.h \
+    $$PWD/src/mqtt/qmqtt_message.h \
+    $$PWD/src/mqtt/qmqtt_message_p.h \
+    $$PWD/src/mqtt/qmqtt_network_p.h \
+    $$PWD/src/mqtt/qmqtt_networkinterface.h \
+    $$PWD/src/mqtt/qmqtt_routedmessage.h \
+    $$PWD/src/mqtt/qmqtt_router.h \
+    $$PWD/src/mqtt/qmqtt_routesubscription.h \
+    $$PWD/src/mqtt/qmqtt_socket_p.h \
+    $$PWD/src/mqtt/qmqtt_socketinterface.h \
+    $$PWD/src/mqtt/qmqtt_timer_p.h \
+    $$PWD/src/mqtt/qmqtt_timerinterface.h \
+    $$PWD/src/mqtt/qmqtt_ssl_socket_p.h
+
+SOURCES += \
+    $$PWD/src/mqtt/qmqtt_client.cpp \
+    $$PWD/src/mqtt/qmqtt_client_p.cpp \
+    $$PWD/src/mqtt/qmqtt_frame.cpp \
+    $$PWD/src/mqtt/qmqtt_message.cpp \
+    $$PWD/src/mqtt/qmqtt_network.cpp \
+    $$PWD/src/mqtt/qmqtt_router.cpp \
+    $$PWD/src/mqtt/qmqtt_routesubscription.cpp \
+    $$PWD/src/mqtt/qmqtt_socket.cpp \
+    $$PWD/src/mqtt/qmqtt_timer.cpp \
+    $$PWD/src/mqtt/qmqtt_ssl_socket.cpp
+
+QMQTT_WEBSOCKETS {
+    PRIVATE_HEADERS += \
+        $$PWD/src/mqtt/qmqtt_websocket_p.h \
+        $$PWD/src/mqtt/qmqtt_websocketiodevice_p.h
+
+    SOURCES += \
+        $$PWD/src/mqtt/qmqtt_websocket.cpp \
+        $$PWD/src/mqtt/qmqtt_websocketiodevice.cpp
+}

--- a/src/mqtt/qmqtt_global.h
+++ b/src/mqtt/qmqtt_global.h
@@ -34,14 +34,12 @@
 
 #include <QtGlobal>
 
-#ifndef QT_STATIC
-#  if defined(QT_BUILD_QMQTT_LIB)
-#    define Q_MQTT_EXPORT Q_DECL_EXPORT
-#  else
-#    define Q_MQTT_EXPORT Q_DECL_IMPORT
-#  endif
-#else
+#if defined(QT_BUILD_QMQTT_LIB)
+#  define Q_MQTT_EXPORT Q_DECL_EXPORT
+#elif defined(QT_BUILD_QMQTT_SRC)
 #  define Q_MQTT_EXPORT
+#else
+#  define Q_MQTT_EXPORT Q_DECL_IMPORT
 #endif
 
 #endif // QMQTT_GLOBAL_H

--- a/src/mqtt/qmqtt_global.h
+++ b/src/mqtt/qmqtt_global.h
@@ -34,12 +34,14 @@
 
 #include <QtGlobal>
 
-#if defined(QT_BUILD_QMQTT_LIB)
-#  define Q_MQTT_EXPORT Q_DECL_EXPORT
-#elif defined(QT_BUILD_QMQTT_SRC)
-#  define Q_MQTT_EXPORT
+#if !defined(QT_STATIC) || !defined(MQTT_PROJECT_INCLUDE_SRC)
+#  if defined(QT_BUILD_QMQTT_LIB)
+#    define Q_MQTT_EXPORT Q_DECL_EXPORT
+#  else
+#    define Q_MQTT_EXPORT Q_DECL_IMPORT
+#  endif
 #else
-#  define Q_MQTT_EXPORT Q_DECL_IMPORT
+#  define Q_MQTT_EXPORT
 #endif
 
 #endif // QMQTT_GLOBAL_H

--- a/src/mqtt/qmqtt_global.h
+++ b/src/mqtt/qmqtt_global.h
@@ -34,7 +34,7 @@
 
 #include <QtGlobal>
 
-#if !defined(QT_STATIC) || !defined(MQTT_PROJECT_INCLUDE_SRC)
+#if !defined(QT_STATIC) && !defined(MQTT_PROJECT_INCLUDE_SRC)
 #  if defined(QT_BUILD_QMQTT_LIB)
 #    define Q_MQTT_EXPORT Q_DECL_EXPORT
 #  else


### PR DESCRIPTION
Hi,

First of all, thanks for this project! I am currently using it in [Serial Studio](https://github.com/serial-studio/serial-studio) for uploading incoming serial/network data to an MQTT broker, which in turns allows the application to display data from any Serial Studio instance connected to the MQTT broker.

To integrate it in Serial Studio, I made some modifications that allow me to "skip" the library linking process and integrate QMQTT directly with my codebase as a submodule. Please let me know if these modifications are ok for you. 

Greetings!

**Edit:** you can see an example qmake code for integrating QMQTT with the `*.pri` file [here](https://github.com/Serial-Studio/Serial-Studio/blob/master/libs/Libraries.pri#L29). The `QT_BUILD_QMQTT_SRC` definition is used in `qmqtt_global.h` to avoid adding export/import symbols to the headers.