### PR TITLE
fix for missing timeout signal

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -563,7 +563,7 @@ void QMQTT::ClientPrivate::setKeepAlive(const quint16 keepAlive)
     _timer.setInterval(keepAlive*1000);
     // The MQTT specification does not mention a timeout value in this case, so we use 10% of the
     // keep alive interval.
-    _pingResponseTimer.setInterval(qBound(keepAlive * 100, 10000, keepAlive * 1000));
+    _pingResponseTimer.setInterval(keepAlive * 100);
 }
 
 quint16 QMQTT::ClientPrivate::keepAlive() const


### PR DESCRIPTION
The interval of the _pingResponseTimer should always be smaller than the keepAlive interval. Otherwise the keepAlive restarts the pingResponseTimer before it can finish. 

Maybe the arguments to qBound were intended in a different order? Then the comment directly above would make sense.