### PR TITLE
Changes to be able to compile the library with Qt 6.2.0.

### DIFF
--- a/qmqtt.pri
+++ b/qmqtt.pri
@@ -12,6 +12,11 @@ INCLUDEPATH += $$PWD/src/mqtt
 DEFINES += MQTT_PROJECT_INCLUDE_SRC
 
 #
+# Optimize compilation times by including MOC C++ code
+#
+DEFINES += MQTT_INCLUDE_MOC=1
+
+#
 # Add header files
 #
 HEADERS += \

--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -410,3 +410,7 @@ void QMQTT::Client::ignoreSslErrors(const QList<QSslError>& errors)
     d->ignoreSslErrors(errors);
 }
 #endif // QT_NO_SSL
+
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_client.cpp"
+#endif

--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -139,7 +139,7 @@ class Q_MQTT_EXPORT Client : public QObject
     Q_PROPERTY(quint8 _willQos READ willQos WRITE setWillQos)
     Q_PROPERTY(bool _willRetain READ willRetain WRITE setWillRetain)
     Q_PROPERTY(QByteArray _willMessage READ willMessage WRITE setWillMessage)
-    Q_PROPERTY(QString _connectionState READ connectionState)
+    Q_PROPERTY(ConnectionState _connectionState READ connectionState)
 #ifndef QT_NO_SSL
     Q_PROPERTY(QSslConfiguration _sslConfiguration READ sslConfiguration WRITE setSslConfiguration)
 #endif // QT_NO_SSL

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -293,3 +293,4 @@ void QMQTT::Network::setSslConfiguration(const QSslConfiguration& config)
     _socket->setSslConfiguration(config);
 }
 #endif // QT_NO_SSL
+

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -294,3 +294,7 @@ void QMQTT::Network::setSslConfiguration(const QSslConfiguration& config)
 }
 #endif // QT_NO_SSL
 
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_network_p.cpp"
+#endif
+

--- a/src/mqtt/qmqtt_router.cpp
+++ b/src/mqtt/qmqtt_router.cpp
@@ -65,3 +65,6 @@ Client *Router::client() const
 
 } // namespace QMQTT
 
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_router.cpp"
+#endif

--- a/src/mqtt/qmqtt_routesubscription.cpp
+++ b/src/mqtt/qmqtt_routesubscription.cpp
@@ -113,5 +113,4 @@ void RouteSubscription::routeMessage(const Message &message)
 
     emit received(routedMessage);
 }
-
 } // namespace QMQTT

--- a/src/mqtt/qmqtt_routesubscription.cpp
+++ b/src/mqtt/qmqtt_routesubscription.cpp
@@ -114,3 +114,7 @@ void RouteSubscription::routeMessage(const Message &message)
     emit received(routedMessage);
 }
 } // namespace QMQTT
+
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_routesubscription.cpp"
+#endif

--- a/src/mqtt/qmqtt_socket.cpp
+++ b/src/mqtt/qmqtt_socket.cpp
@@ -83,3 +83,7 @@ QAbstractSocket::SocketError QMQTT::Socket::error() const
 {
     return _socket->error();
 }
+
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_socket_p.cpp"
+#endif

--- a/src/mqtt/qmqtt_ssl_socket.cpp
+++ b/src/mqtt/qmqtt_ssl_socket.cpp
@@ -113,4 +113,8 @@ void QMQTT::SslSocket::setSslConfiguration(const QSslConfiguration& config)
     _socket->setSslConfiguration(config);
 }
 
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_ssl_socket_p.cpp"
+#endif
+
 #endif // QT_NO_SSL

--- a/src/mqtt/qmqtt_timer.cpp
+++ b/src/mqtt/qmqtt_timer.cpp
@@ -71,3 +71,7 @@ void QMQTT::Timer::stop()
 {
     _timer.stop();
 }
+
+#if MQTT_INCLUDE_MOC
+#include "moc_qmqtt_timer_p.cpp"
+#endif


### PR DESCRIPTION
Trying to compile the library with Qt 6 results with the following error:

<img width="1050" alt="Screen Shot 2021-09-28 at 14 51 08" src="https://user-images.githubusercontent.com/4225542/135156132-30734259-ccea-412a-9c58-d6e5d369fd19.png">

The fix that I came up with was simply changing the `QString` in the `Q_PROPERTY` to an `int` or a `ConnectionState` type.

