### PR TITLE
Check internal connection state instead of socket state in QMQTT::isConnectedToHost()

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -376,6 +376,7 @@ void QMQTT::ClientPrivate::onNetworkDisconnected()
     stopKeepAlive();
     _midToTopic.clear();
     _midToMessage.clear();
+    _connectionState = ConnectionState::STATE_DISCONNECTED;
     emit q->disconnected();
 }
 
@@ -539,7 +540,7 @@ void QMQTT::ClientPrivate::setAutoReconnectInterval(const int autoReconnectInter
 
 bool QMQTT::ClientPrivate::isConnectedToHost() const
 {
-    return _network->isConnectedToHost();
+    return _connectionState == ConnectionState::STATE_CONNECTED;
 }
 
 QMQTT::ConnectionState QMQTT::ClientPrivate::connectionState() const


### PR DESCRIPTION
The isConnectedToHost function should not return true, if a TCP
connection has been established already, but the handshake (CONNNECT /
CONNACK massages) with the broker has not been completed yet.

This should fix issue #230 