### PR TITLE
Fix publishing packet ID zero on wrap-around

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -335,7 +335,12 @@ void QMQTT::ClientPrivate::stopKeepAlive()
 
 quint16 QMQTT::ClientPrivate::nextmid()
 {
-    return _gmid++;
+    const quint16 result = _gmid;
+    _gmid++;
+    if (_gmid == 0)
+      _gmid++;
+
+    return result;
 }
 
 quint16 QMQTT::ClientPrivate::publish(const Message& message)


### PR DESCRIPTION
"SUBSCRIBE, UNSUBSCRIBE, and PUBLISH (in cases where QoS > 0) Control
Packets MUST contain a non-zero 16-bit Packet Identifier
[MQTT-2.3.1-1]."