### PR TITLE
Revert "Changes to be able to compile the library with Qt 6.2.0."

### DIFF
--- a/qmqtt.pri
+++ b/qmqtt.pri
@@ -12,11 +12,6 @@ INCLUDEPATH += $$PWD/src/mqtt
 DEFINES += MQTT_PROJECT_INCLUDE_SRC
 
 #
-# Optimize compilation times by including MOC C++ code
-#
-DEFINES += MQTT_INCLUDE_MOC=1
-
-#
 # Add header files
 #
 HEADERS += \

--- a/src/mqtt/qmqtt_client.cpp
+++ b/src/mqtt/qmqtt_client.cpp
@@ -410,7 +410,3 @@ void QMQTT::Client::ignoreSslErrors(const QList<QSslError>& errors)
     d->ignoreSslErrors(errors);
 }
 #endif // QT_NO_SSL
-
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_client.cpp"
-#endif

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -293,8 +293,3 @@ void QMQTT::Network::setSslConfiguration(const QSslConfiguration& config)
     _socket->setSslConfiguration(config);
 }
 #endif // QT_NO_SSL
-
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_network_p.cpp"
-#endif
-

--- a/src/mqtt/qmqtt_router.cpp
+++ b/src/mqtt/qmqtt_router.cpp
@@ -65,6 +65,3 @@ Client *Router::client() const
 
 } // namespace QMQTT
 
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_router.cpp"
-#endif

--- a/src/mqtt/qmqtt_routesubscription.cpp
+++ b/src/mqtt/qmqtt_routesubscription.cpp
@@ -113,8 +113,5 @@ void RouteSubscription::routeMessage(const Message &message)
 
     emit received(routedMessage);
 }
-} // namespace QMQTT
 
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_routesubscription.cpp"
-#endif
+} // namespace QMQTT

--- a/src/mqtt/qmqtt_socket.cpp
+++ b/src/mqtt/qmqtt_socket.cpp
@@ -83,7 +83,3 @@ QAbstractSocket::SocketError QMQTT::Socket::error() const
 {
     return _socket->error();
 }
-
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_socket_p.cpp"
-#endif

--- a/src/mqtt/qmqtt_ssl_socket.cpp
+++ b/src/mqtt/qmqtt_ssl_socket.cpp
@@ -113,8 +113,4 @@ void QMQTT::SslSocket::setSslConfiguration(const QSslConfiguration& config)
     _socket->setSslConfiguration(config);
 }
 
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_ssl_socket_p.cpp"
-#endif
-
 #endif // QT_NO_SSL

--- a/src/mqtt/qmqtt_timer.cpp
+++ b/src/mqtt/qmqtt_timer.cpp
@@ -71,7 +71,3 @@ void QMQTT::Timer::stop()
 {
     _timer.stop();
 }
-
-#if MQTT_INCLUDE_MOC
-#include "moc_qmqtt_timer_p.cpp"
-#endif


### PR DESCRIPTION
Unfortunately this breaks the build on Qt5:

```
.obj/qmqtt_client_p.o: In function `QMQTT::ClientPrivate::onSslErrors(QList<QSslError> const&)':
/home/mdw/progs/c_cpp/qmqtt/src/mqtt/qmqtt_client_p.cpp:803: undefined reference to `QMQTT::Client::sslErrors(QList<QSslError> const&)'
.obj/qmqtt_client_p.o: In function `QMQTT::ClientPrivate::publish(QMQTT::Message const&)':
/home/mdw/progs/c_cpp/qmqtt/src/mqtt/qmqtt_client_p.cpp:353: undefined reference to `QMQTT::Client::published(QMQTT::Message const&, unsigned short)'
.obj/qmqtt_client_p.o: In function `QMQTT::ClientPrivate::handlePuback(unsigned char, unsigned short)':
/home/mdw/progs/c_cpp/qmqtt/src/mqtt/qmqtt_client_p.cpp:501: undefined reference to `QMQTT::Client::published(QMQTT::Message const&, unsigned short)'
.obj/qmqtt_client_p.o: In function `QMQTT::ClientPrivate::onPingTimeout()':
/home/mdw/progs/c_cpp/qmqtt/src/mqtt/qmqtt_client_p.cpp:307: undefined reference to
```
etc. etc.