### PR TITLE
Errors found by the PVS studio static analyzer.

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -52,6 +52,9 @@ static const quint8 QOS2 = 0x02;
 QMQTT::ClientPrivate::ClientPrivate(Client* qq_ptr)
     : _host(QHostAddress::LocalHost)
     , _port(1883)
+#ifndef QT_NO_SSL
+    , _ignoreSelfSigned(false)
+#endif // QT_NO_SSL
     , _gmid(1)
     , _version(MQTTVersion::V3_1_0)
     , _clientId(QUuid::createUuid().toString())

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -49,8 +49,8 @@ QMQTT::Network::Network(QObject* parent)
     , _port(DEFAULT_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::Socket(this))
-    , _autoReconnectTimer(new QMQTT::Timer(this))
+    , _socket(new QMQTT::Socket)
+    , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
 {
     initialize();
@@ -62,8 +62,8 @@ QMQTT::Network::Network(const QSslConfiguration& config, QObject *parent)
     , _port(DEFAULT_SSL_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::SslSocket(config, this))
-    , _autoReconnectTimer(new QMQTT::Timer(this))
+    , _socket(new QMQTT::SslSocket(config))
+    , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
 {
     initialize();

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -49,8 +49,8 @@ QMQTT::Network::Network(QObject* parent)
     , _port(DEFAULT_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::Socket)
-    , _autoReconnectTimer(new QMQTT::Timer)
+    , _socket(new QMQTT::Socket(this))
+    , _autoReconnectTimer(new QMQTT::Timer(this))
     , _readState(Header)
 {
     initialize();
@@ -62,8 +62,8 @@ QMQTT::Network::Network(const QSslConfiguration& config, QObject *parent)
     , _port(DEFAULT_SSL_PORT)
     , _autoReconnect(DEFAULT_AUTORECONNECT)
     , _autoReconnectInterval(DEFAULT_AUTORECONNECT_INTERVAL_MS)
-    , _socket(new QMQTT::SslSocket(config))
-    , _autoReconnectTimer(new QMQTT::Timer)
+    , _socket(new QMQTT::SslSocket(config, this))
+    , _autoReconnectTimer(new QMQTT::Timer(this))
     , _readState(Header)
 {
     initialize();


### PR DESCRIPTION
Errors found by the PVS studio static analyzer:
qmqtt_client_p.cpp	52	warn	V730 It is possible that not all members of a class are initialized inside the constructor. Consider inspecting: _ignoreSelfSigned.
qmqtt_network.cpp	140	warn	V773 The '_socket' pointer was not released in destructor. A memory leak is possible.
qmqtt_network.cpp	140	warn	V773 The '_autoReconnectTimer' pointer was not released in destructor. A memory leak is possible.