### PR TITLE
Lower Qt6 version from 6.5.0 to 6.2.4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ endif()
 set( ws_component )
 set( ws_libname )
 set( qt5_min_version "5.3.0" )
-set( qt6_min_version "6.5.0" )
+set( qt6_min_version "6.2.4" )
 
 if ( ${PROJECT_NAME}_WEBSOCKETS )
     set( ws_component WebSockets )


### PR DESCRIPTION
Requirement for Qt 6.5.0 seems arbitrary. It also works with 6.2.4 (e.g. for older Ubuntu versions).

Hope this helps :)