### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -1,0 +1,11 @@
+# https://docs.github.com/en/actions
+# https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python
+# https://docs.astral.sh/ruff
+name: lint_python
+on: [pull_request, push]
+jobs:
+  lint_python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3


### PR DESCRIPTION
* https://docs.github.com/en/actions
* https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python
* https://docs.astral.sh/ruff

The [`googletest`](https://github.com/google/googletest) vendored into this codebase was never ported to Python 3, so it has at least 64 files containing Python Syntax Errors.  It should be re-vendored or removed if it is no longer used.