### PR TITLE
performance optimization

### DIFF
--- a/src/mqtt/qmqtt_frame.cpp
+++ b/src/mqtt/qmqtt_frame.cpp
@@ -42,18 +42,21 @@ Q_LOGGING_CATEGORY(frame, "qmqtt.frame")
 Frame::Frame()
     : _header(0)
     , _data(QByteArray())
+    , _readOffset(0)
 {
 }
 
 Frame::Frame(const quint8 header)
     : _header(header)
     , _data(QByteArray())
+    , _readOffset(0)
 {
 }
 
 Frame::Frame(const quint8 header, const QByteArray &data)
     : _header(header)
     , _data(data)
+    , _readOffset(0)
 {
 }
 
@@ -61,12 +64,14 @@ Frame::Frame(const Frame& other)
 {
     _header = other._header;
     _data = other._data;
+    _readOffset = other._readOffset;
 }
 
 Frame& Frame::operator=(const Frame& other)
 {
     _header = other._header;
     _data = other._data;
+    _readOffset = other._readOffset;
     return *this;
 }
 
@@ -88,37 +93,51 @@ quint8 Frame::header() const
 
 QByteArray Frame::data() const
 {
+    if (_readOffset >= _data.size()) {
+        return QByteArray();
+    }
+    if (_readOffset > 0) {
+        return _data.mid(_readOffset);
+    }
     return _data;
 }
 
 quint8 Frame::readChar()
 {
-    char c = _data.at(0);
-    _data.remove(0, 1);
+    if (_readOffset >= _data.size()) return 0;
+    quint8 c = static_cast<quint8>(_data.at(_readOffset));
+    _readOffset++;
     return c;
 }
 
 quint16 Frame::readInt()
 {
-    quint8 msb = static_cast<quint8>(_data.at(0));
-    quint8 lsb = static_cast<quint8>(_data.at(1));
-    _data.remove(0, 2);
+    if (_readOffset + 1 >= _data.size()) return 0;
+    quint8 msb = static_cast<quint8>(_data.at(_readOffset));
+    quint8 lsb = static_cast<quint8>(_data.at(_readOffset + 1));
+    _readOffset += 2;
     return (msb << 8) | lsb;
 }
 
 QByteArray Frame::readByteArray()
 {
     quint16 len = readInt();
-    QByteArray data = _data.left(len);
-    _data.remove(0, len);
+    if (len > _data.size() - _readOffset) {
+        len = _data.size() - _readOffset;
+    }
+    QByteArray data = _data.mid(_readOffset, len);
+    _readOffset += len;
     return data;
 }
 
 QString Frame::readString()
 {
     quint16 len = readInt();
-    QString s = QString::fromUtf8(_data.left(len));
-    _data.remove(0, len);
+    if (len > _data.size() - _readOffset) {
+        len = _data.size() - _readOffset;
+    }
+    QString s = QString::fromUtf8(_data.constData() + _readOffset, len);
+    _readOffset += len;
     return s;
 }
 

--- a/src/mqtt/qmqtt_frame.h
+++ b/src/mqtt/qmqtt_frame.h
@@ -60,8 +60,8 @@ QT_FORWARD_DECLARE_CLASS(QDataStream)
 #define PINGRESP 0xD0
 #define DISCONNECT 0xE0
 
-#define LSB(A) quint8(A & 0x00FF)
-#define MSB(A) quint8((A & 0xFF00) >> 8)
+constexpr inline quint8 LSB(quint16 A) { return quint8(A & 0x00FF); }
+constexpr inline quint8 MSB(quint16 A) { return quint8((A & 0xFF00) >> 8); }
 
 /*
 |--------------------------------------
@@ -69,13 +69,13 @@ QT_FORWARD_DECLARE_CLASS(QDataStream)
 |  Type   | DUP flag |  QoS  | RETAIN |
 |--------------------------------------
 */
-#define GETTYPE(HDR)		(HDR & 0xF0)
-#define SETQOS(HDR, Q)		(HDR | ((Q) << 1))
-#define GETQOS(HDR)			((HDR & 0x06) >> 1)
-#define SETDUP(HDR, D)		(HDR | ((D) << 3))
-#define GETDUP(HDR)			((HDR & 0x08) >> 3)
-#define SETRETAIN(HDR, R)	(HDR | (R))
-#define GETRETAIN(HDR)		(HDR & 0x01)
+constexpr inline quint8 GETTYPE  (quint8 HDR)           { return HDR & 0xF0; }
+constexpr inline quint8 SETQOS   (quint8 HDR, quint8 Q) { return (HDR & ~0x06) | ((Q & 0x03) << 1); }
+constexpr inline quint8 GETQOS   (quint8 HDR)           { return (HDR & 0x06) >> 1; }
+constexpr inline quint8 SETDUP   (quint8 HDR, quint8 D) { return (HDR & ~0x08) | ((D & 0x01) << 3); }
+constexpr inline quint8 GETDUP   (quint8 HDR)           { return (HDR & 0x08) >> 3; }
+constexpr inline quint8 SETRETAIN(quint8 HDR, quint8 R) { return (HDR & ~0x01) | (R & 0x01); }
+constexpr inline quint8 GETRETAIN(quint8 HDR)           { return HDR & 0x01; }
 
 /*
 |----------------------------------------------------------------------------------
@@ -83,12 +83,12 @@ QT_FORWARD_DECLARE_CLASS(QDataStream)
 | username | password | willretain | willqos | willflag | cleansession | reserved |
 |----------------------------------------------------------------------------------
 */
-#define FLAG_CLEANSESS(F, C)	(F | ((C) << 1))
-#define FLAG_WILL(F, W)			(F | ((W) << 2))
-#define FLAG_WILLQOS(F, Q)		(F | ((Q) << 3))
-#define FLAG_WILLRETAIN(F, R) 	(F | ((R) << 5))
-#define FLAG_PASSWD(F, P)		(F | ((P) << 6))
-#define FLAG_USERNAME(F, U)		(F | ((U) << 7))
+constexpr inline quint8 FLAG_CLEANSESS (quint8 F, quint8 C) { return (F & ~0x02) | ((C & 0x01) << 1); }
+constexpr inline quint8 FLAG_WILL      (quint8 F, quint8 W) { return (F & ~0x04) | ((W & 0x01) << 2); }
+constexpr inline quint8 FLAG_WILLQOS   (quint8 F, quint8 Q) { return (F & ~0x18) | ((Q & 0x03) << 3); }
+constexpr inline quint8 FLAG_WILLRETAIN(quint8 F, quint8 R) { return (F & ~0x20) | ((R & 0x01) << 5); }
+constexpr inline quint8 FLAG_PASSWD    (quint8 F, quint8 P) { return (F & ~0x40) | ((P & 0x01) << 6); }
+constexpr inline quint8 FLAG_USERNAME  (quint8 F, quint8 U) { return (F & ~0x80) | ((U & 0x01) << 7); }
 
 namespace QMQTT {
 

--- a/src/mqtt/qmqtt_frame.h
+++ b/src/mqtt/qmqtt_frame.h
@@ -128,6 +128,7 @@ public:
 private:
     quint8 _header;
     QByteArray _data;
+    int _readOffset;
 };
 
 } // namespace QMQTT

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -52,6 +52,7 @@ QMQTT::Network::Network(QObject* parent)
     , _socket(new QMQTT::Socket)
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
+    , _readPos(0)
 {
     initialize();
 }
@@ -65,6 +66,7 @@ QMQTT::Network::Network(const QSslConfiguration& config, QObject *parent)
     , _socket(new QMQTT::SslSocket(config))
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
+    , _readPos(0)
 {
     initialize();
     connect(_socket, &QMQTT::SslSocket::sslErrors, this, &QMQTT::Network::sslErrors);
@@ -84,6 +86,7 @@ QMQTT::Network::Network(const QString& origin,
     , _socket(new QMQTT::WebSocket(origin, version, sslConfig))
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
+    , _readPos(0)
 {
     initialize();
 }
@@ -99,6 +102,7 @@ QMQTT::Network::Network(const QString& origin,
     , _socket(new QMQTT::WebSocket(origin, version))
     , _autoReconnectTimer(new QMQTT::Timer)
     , _readState(Header)
+    , _readPos(0)
 {
     initialize();
 }
@@ -113,6 +117,7 @@ QMQTT::Network::Network(SocketInterface* socketInterface, TimerInterface* timerI
     , _socket(socketInterface)
     , _autoReconnectTimer(timerInterface)
     , _readState(Header)
+    , _readPos(0)
 {
     initialize();
 }
@@ -223,45 +228,70 @@ void QMQTT::Network::onSocketReadReady()
 {
     QIODevice *ioDevice = _socket->ioDevice();
     // Only read the available (cached) bytes, so the read will never block.
-    QByteArray data = ioDevice->read(ioDevice->bytesAvailable());
-    foreach(char byte, data) {
-        switch (_readState) {
-        case Header:
-            _header = static_cast<quint8>(byte);
+    _data.append(ioDevice->read(ioDevice->bytesAvailable()));
+
+    while (_readPos < _data.size()) {
+        if (_readState == Header) {
+            _header = static_cast<quint8>(_data.at(_readPos++));
             _readState = Length;
             _length = 0;
             _shift = 0;
-            _data.resize(0); // keep allocated buffer
-            break;
-        case Length:
-            _length |= (byte & 0x7F) << _shift;
-            _shift += 7;
-            if ((byte & 0x80) != 0) {
-                if (_shift > 21) { // only up to 4 bytes (3*7 shifts)
-                    _readState = Header;
-                    emit error(QAbstractSocket::SocketError::UnknownSocketError);
+        }
+
+        if (_readState == Length) {
+            bool lengthComplete = false;
+            while (_readPos < _data.size()) {
+                char byte = _data.at(_readPos++);
+                _length |= (byte & 0x7F) << _shift;
+                _shift += 7;
+                if ((byte & 0x80) != 0) {
+                    if (_shift > 21) { // only up to 4 bytes (3*7 shifts)
+                        _readState = Header;
+                        _length = 0;
+                        _shift = 0;
+                        emit error(QAbstractSocket::SocketError::UnknownSocketError);
+                        _data.clear();
+                        _readPos = 0;
+                        return;
+                    }
+                    continue;
                 }
+                lengthComplete = true;
                 break;
             }
+
+            if (!lengthComplete) break;
+
             if (_length == 0) {
                 _readState = Header;
-                Frame frame(_header, _data);
+                Frame frame(_header, QByteArray());
                 emit received(frame);
-                break;
+                continue;
             }
             _readState = PayLoad;
-            _data.reserve(_length);
-            break;
-        case PayLoad:
-            _data.append(byte);
-            --_length;
-            if (_length > 0)
-                break;
-            _readState = Header;
-            Frame frame(_header, _data);
-            emit received(frame);
-            break;
         }
+
+        if (_readState == PayLoad) {
+            int available = _data.size() - _readPos;
+            if (available < _length) break;
+
+            QByteArray payload = _data.mid(_readPos, _length);
+            _readPos += _length;
+
+            _readState = Header;
+            Frame frame(_header, payload);
+            emit received(frame);
+
+            if (_readPos == _data.size()) {
+                _data.clear();
+                _readPos = 0;
+            }
+        }
+    }
+
+    if (_readPos > 0 && _data.size() - _readPos < 1024) {
+        _data.remove(0, _readPos);
+        _readPos = 0;
     }
 }
 

--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -123,6 +123,7 @@ protected:
     quint8 _header;
     int _length;
     int _shift;
+    int _readPos;
     QByteArray _data;
 
 protected Q_SLOTS:

--- a/src/mqtt/qmqtt_websocketiodevice.cpp
+++ b/src/mqtt/qmqtt_websocketiodevice.cpp
@@ -32,9 +32,10 @@ void QMQTT::WebSocketIODevice::binaryMessageReceived(const QByteArray &frame)
 
 qint64 QMQTT::WebSocketIODevice::readData(char *data, qint64 maxSize)
 {
-    int size = qMin(static_cast<int>(maxSize), _buffer.count());
-    for (int i=0; i<size; ++ i)
-        data[i] = _buffer[i];
+    int size = qMin(static_cast<int>(maxSize), _buffer.size());
+    if (size <= 0) return 0;
+
+    memcpy(data, _buffer.constData(), size);
     _buffer.remove(0, size);
     return size;
 }


### PR DESCRIPTION
onSocketReadReady: Reading from the socket processes data 1 byte at a time in a foreach loop. Kills performance on large payloads. Needs to read in blocks.
Frame: readChar, readInt methods remove the beginning of the array. O(n) complexity for each read. Needs to use a cursor index (offset).