### PR TITLE
Session persistence and QoS 1/2 message retransmission on disconnect

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -194,6 +194,11 @@ void QMQTT::ClientPrivate::onNetworkConnected()
 
 void QMQTT::ClientPrivate::sendConnect()
 {
+    if (_cleanSession) {
+        _midToTopic.clear();
+        _midToMessage.clear();
+    }
+
     quint8 header = CONNECT;
     quint8 flags = 0;
 
@@ -256,10 +261,6 @@ quint16 QMQTT::ClientPrivate::sendPublish(const Message &message)
     Frame frame(header);
     frame.writeString(message.topic());
     if(message.qos() > QOS0) {
-        if (msgid == 0) {
-            msgid = nextmid();
-            if (msgid == 0) return 0;
-        }
         frame.writeInt(msgid);
     }
     if(!message.payload().isEmpty()) {
@@ -360,18 +361,30 @@ quint16 QMQTT::ClientPrivate::nextmid()
 quint16 QMQTT::ClientPrivate::publish(const Message& message)
 {
     Q_Q(Client);
-    quint16 msgid = sendPublish(message);
 
-    // Emit published only at QOS0
-    if (message.qos() == QOS0)
+    if (message.qos() == QOS0) {
+        quint16 msgid = sendPublish(message);
         emit q->published(message, msgid);
-    else if (msgid == 0) {
-        emit q->error(MqttOutOfPacketIdsError);
-    } else {
-        _midToMessage[msgid] = message;
+        return msgid;
     }
 
-    return msgid;
+    Message msg = message;
+    if (msg.id() == 0) {
+        quint16 newId = nextmid();
+        if (newId == 0) {
+            emit q->error(MqttOutOfPacketIdsError);
+            return 0;
+        }
+        msg.setId(newId);
+    }
+
+    _midToMessage[msg.id()] = msg;
+
+    if (_connectionState == STATE_CONNECTED) {
+        sendPublish(msg);
+    }
+
+    return msg.id();
 }
 
 void QMQTT::ClientPrivate::puback(const quint8 type, const quint16 msgid)
@@ -404,8 +417,12 @@ void QMQTT::ClientPrivate::onNetworkDisconnected()
     Q_Q(Client);
 
     stopKeepAlive();
-    _midToTopic.clear();
-    _midToMessage.clear();
+
+    if (_cleanSession) {
+        _midToTopic.clear();
+        _midToMessage.clear();
+    }
+
     _connectionState = ConnectionState::STATE_DISCONNECTED;
     emit q->disconnected();
 }
@@ -471,6 +488,12 @@ void QMQTT::ClientPrivate::handleConnack(const quint8 ack)
     case 0:
         _connectionState = ConnectionState::STATE_CONNECTED;
         emit q->connected();
+
+        for (const Message& msg : _midToMessage) {
+            Message retransmitMsg = msg;
+            retransmitMsg.setDup(true);
+            sendPublish(retransmitMsg);
+        }
         break;
     case 1:
         emit q->error(MqttUnacceptableProtocolVersionError);

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -104,7 +104,7 @@ public:
     bool _willRetain;
     QByteArray _willMessage;
     QHash<quint16, QString> _midToTopic;
-    QHash<quint16, Message> _midToMessage;
+    QMap <quint16, Message> _midToMessage;
 
     Client* const q_ptr;
 


### PR DESCRIPTION
Previously, upon network disconnection, the library unconditionally deleted all unacknowledged messages (QoS 1/2) from memory, ignoring the cleanSession flag. Furthermore, calling publish while offline resulted in silent data loss: the message was sent into the void and was not stored anywhere.

Solution:
1. On disconnect, the _midToMessage and _midToTopic are now cleared only if the cleanSession = true flag is set.
2. If publish is called while disconnected, the message is assigned a valid ID, stored in the pending map, and waits for the connection to be restored.
3. Upon successful reconnection, all pending messages are automatically retransmitted to the broker with the DUP=true flag set.