### PR TITLE
Incorrect handling of incoming QoS 2 messages

### DIFF
--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -197,6 +197,7 @@ void QMQTT::ClientPrivate::sendConnect()
     if (_cleanSession) {
         _midToTopic.clear();
         _midToMessage.clear();
+        _midToIncomingQos2.clear();
     }
 
     quint8 header = CONNECT;
@@ -421,6 +422,7 @@ void QMQTT::ClientPrivate::onNetworkDisconnected()
     if (_cleanSession) {
         _midToTopic.clear();
         _midToMessage.clear();
+        _midToIncomingQos2.clear();
     }
 
     _connectionState = ConnectionState::STATE_DISCONNECTED;
@@ -523,12 +525,19 @@ void QMQTT::ClientPrivate::handlePublish(const Message& message)
     if(message.qos() == QOS1)
     {
         sendPuback(PUBACK, message.id());
+        emit q->received(message);
     }
     else if(message.qos() == QOS2)
     {
+        if (!_midToIncomingQos2.contains(message.id())) {
+            _midToIncomingQos2.insert(message.id(), message);
+        }
         sendPuback(PUBREC, message.id());
     }
-    emit q->received(message);
+    else // QoS 0
+    {
+        emit q->received(message);
+    }
 }
 
 void QMQTT::ClientPrivate::handlePuback(const quint8 type, const quint16 msgid)
@@ -541,6 +550,9 @@ void QMQTT::ClientPrivate::handlePuback(const quint8 type, const quint16 msgid)
         sendPuback(SETQOS(PUBREL, QOS1), msgid);
         break;
     case PUBREL:
+        if (_midToIncomingQos2.contains(msgid)) {
+            emit q->received(_midToIncomingQos2.take(msgid));
+        }
         sendPuback(PUBCOMP, msgid);
         break;
     case PUBACK:

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -105,6 +105,7 @@ public:
     QByteArray _willMessage;
     QHash<quint16, QString> _midToTopic;
     QMap <quint16, Message> _midToMessage;
+    QHash<quint16, Message> _midToIncomingQos2;
 
     Client* const q_ptr;
 


### PR DESCRIPTION
Upon receiving a QoS 2 message, the library immediately emitted the received signal to the application and sent PUBREC to the broker. If the connection dropped at this stage, the broker would resend the PUBLISH, causing the application to process the message again, violating the Exactly-Once delivery guarantee.

Solution:
The message is now stored in a temporary hash (_midToIncomingQos2) upon receiving PUBLISH. The received signal is emitted only after PUBREL is received from the broker. Duplicate PUBLISH packets (with the same ID) are ignored to prevent reprocessing.