### PR TITLE
Code modernization (C++11/Qt 5), type safety improvements, and cppche…

### DIFF
--- a/src/mqtt/qmqtt_client.h
+++ b/src/mqtt/qmqtt_client.h
@@ -39,8 +39,8 @@
 #include <QHostAddress>
 #include <QByteArray>
 #include <QAbstractSocket>
-#include <QScopedPointer>
 #include <QList>
+#include <memory>
 
 #ifdef QT_WEBSOCKETS_LIB
 #include <QWebSocket>
@@ -146,9 +146,9 @@ class Q_MQTT_EXPORT Client : public QObject
 #endif // QT_NO_SSL
 
 public:
-    Client(const QHostAddress& host = QHostAddress::LocalHost,
-           const quint16 port = 1883,
-           QObject* parent = nullptr);
+    explicit Client(const QHostAddress& host = QHostAddress::LocalHost,
+                    const quint16 port = 1883,
+                    QObject* parent = nullptr);
 
 #ifndef QT_NO_SSL
     Client(const QString& hostName,
@@ -187,10 +187,10 @@ public:
 #endif // QT_WEBSOCKETS_LIB
 
     // for testing purposes only
-    Client(NetworkInterface* network,
-           const QHostAddress& host = QHostAddress::LocalHost,
-           const quint16 port = 1883,
-           QObject* parent = nullptr);
+    explicit Client(NetworkInterface* network,
+                    const QHostAddress& host = QHostAddress::LocalHost,
+                    const quint16 port = 1883,
+                    QObject* parent = nullptr);
 
     virtual ~Client();
 
@@ -273,7 +273,7 @@ protected Q_SLOTS:
 #endif // QT_NO_SSL
 
 protected:
-    QScopedPointer<ClientPrivate> d_ptr;
+    std::unique_ptr<ClientPrivate> d_ptr;
 
 private:
     Q_DISABLE_COPY(Client)

--- a/src/mqtt/qmqtt_client_p.cpp
+++ b/src/mqtt/qmqtt_client_p.cpp
@@ -95,7 +95,7 @@ void QMQTT::ClientPrivate::init(const QString& hostName, const quint16 port,
     _port = port;
     _ignoreSelfSigned = ignoreSelfSigned;
     init(new Network(config, q));
-    QObject::connect(_network.data(), &QMQTT::Network::sslErrors, q, &QMQTT::Client::onSslErrors);
+    QObject::connect(_network.get(), &QMQTT::Network::sslErrors, q, &QMQTT::Client::onSslErrors);
 }
 #endif // QT_NO_SSL
 
@@ -164,13 +164,13 @@ void QMQTT::ClientPrivate::init(NetworkInterface* network)
 
     QObject::connect(&_timer, &QTimer::timeout, q, &Client::onTimerPingReq);
     QObject::connect(&_pingResponseTimer, &QTimer::timeout, q, &Client::onPingTimeout);
-    QObject::connect(_network.data(), &Network::connected,
+    QObject::connect(_network.get(), &Network::connected,
                      q, &Client::onNetworkConnected);
-    QObject::connect(_network.data(), &Network::disconnected,
+    QObject::connect(_network.get(), &Network::disconnected,
                      q, &Client::onNetworkDisconnected);
-    QObject::connect(_network.data(), &Network::received,
+    QObject::connect(_network.get(), &Network::received,
                      q, &Client::onNetworkReceived);
-    QObject::connect(_network.data(), &Network::error,
+    QObject::connect(_network.get(), &Network::error,
                      q, &Client::onNetworkError);
 }
 
@@ -223,11 +223,11 @@ void QMQTT::ClientPrivate::sendConnect()
     //payload
     if(_version == V3_1_1)
     {
-        frame.writeString(QStringLiteral(PROTOCOL_MAGIC_3_1_1));
+        frame.writeString(QString::fromUtf8(PROTOCOL_MAGIC_3_1_1));
     }
     else
     {
-        frame.writeString(QStringLiteral(PROTOCOL_MAGIC_3_1_0));
+        frame.writeString(QString::fromUtf8(PROTOCOL_MAGIC_3_1_0));
     }
     frame.writeChar(_version);
     frame.writeChar(flags);
@@ -864,7 +864,7 @@ void QMQTT::ClientPrivate::onSslErrors(const QList<QSslError>& errors)
 
     if (!_ignoreSelfSigned)
         return;
-    foreach (QSslError error, errors)
+    for (const QSslError& error : errors)
     {
         if (error.error() != QSslError::SelfSignedCertificate &&
             error.error() != QSslError::SelfSignedCertificateInChain)

--- a/src/mqtt/qmqtt_client_p.h
+++ b/src/mqtt/qmqtt_client_p.h
@@ -57,7 +57,7 @@ class NetworkInterface;
 class ClientPrivate
 {
 public:
-    ClientPrivate(Client* qq_ptr);
+    explicit ClientPrivate(Client* qq_ptr);
     ~ClientPrivate();
 
     void init(const QHostAddress& host, const quint16 port, NetworkInterface* network = nullptr);
@@ -96,7 +96,7 @@ public:
     QByteArray _password;
     bool _cleanSession;
     ConnectionState _connectionState;
-    QScopedPointer<NetworkInterface> _network;
+    std::unique_ptr<NetworkInterface> _network;
     QTimer _timer;
     QTimer _pingResponseTimer;
     QString _willTopic;

--- a/src/mqtt/qmqtt_frame.cpp
+++ b/src/mqtt/qmqtt_frame.cpp
@@ -61,10 +61,10 @@ Frame::Frame(const quint8 header, const QByteArray &data)
 }
 
 Frame::Frame(const Frame& other)
+    : _header(other._header)
+    , _data(other._data)
+    , _readOffset(other._readOffset)
 {
-    _header = other._header;
-    _data = other._data;
-    _readOffset = other._readOffset;
 }
 
 Frame& Frame::operator=(const Frame& other)
@@ -125,9 +125,9 @@ QByteArray Frame::readByteArray()
     if (len > _data.size() - _readOffset) {
         len = _data.size() - _readOffset;
     }
-    QByteArray data = _data.mid(_readOffset, len);
+    QByteArray ba = _data.mid(_readOffset, len);
     _readOffset += len;
-    return data;
+    return ba;
 }
 
 QString Frame::readString()
@@ -147,30 +147,30 @@ void Frame::writeInt(const quint16 i)
     _data.append(LSB(i));
 }
 
-void Frame::writeByteArray(const QByteArray &data)
+void Frame::writeByteArray(const QByteArray &ba)
 {
-    if (data.size() > (int)USHRT_MAX)
+    if (ba.size() > (int)USHRT_MAX)
     {
         qCritical("qmqtt: Binary data size bigger than %u bytes, truncate it!", USHRT_MAX);
         writeInt(USHRT_MAX);
-        _data.append(data.left(USHRT_MAX));
+        _data.append(ba.left(USHRT_MAX));
         return;
     }
 
-    writeInt(data.size());
-    _data.append(data);
+    writeInt(ba.size());
+    _data.append(ba);
 }
 
 void Frame::writeString(const QString &string)
 {
-    QByteArray data = string.toUtf8();
-    if (data.size() > (int)USHRT_MAX)
+    QByteArray ba = string.toUtf8();
+    if (ba.size() > (int)USHRT_MAX)
     {
         qCritical("qmqtt: String size bigger than %u bytes, truncate it!", USHRT_MAX);
-        data.resize(USHRT_MAX);
+        ba.resize(USHRT_MAX);
     }
-    writeInt(data.size());
-    _data.append(data);
+    writeInt(ba.size());
+    _data.append(ba);
 }
 
 void Frame::writeChar(const quint8 c)
@@ -212,9 +212,8 @@ void Frame::write(QDataStream &stream) const
 bool Frame::encodeLength(QByteArray &lenbuf, int length) const
 {
     lenbuf.clear();
-    quint8 d;
     do {
-        d = length % 128;
+        quint8 d = length % 128;
         length /= 128;
         if (length > 0) {
             d |= 0x80;

--- a/src/mqtt/qmqtt_frame.h
+++ b/src/mqtt/qmqtt_frame.h
@@ -40,25 +40,25 @@
 
 QT_FORWARD_DECLARE_CLASS(QDataStream)
 
-#define PROTOCOL_MAGIC_3_1_0 "MQIsdp"
-#define PROTOCOL_MAGIC_3_1_1 "MQTT"
+constexpr char PROTOCOL_MAGIC_3_1_0[] = "MQIsdp";
+constexpr char PROTOCOL_MAGIC_3_1_1[] = "MQTT";
 
-#define RANDOM_CLIENT_PREFIX "QMQTT-"
+constexpr char RANDOM_CLIENT_PREFIX[] = "QMQTT-";
 
-#define CONNECT 0x10
-#define CONNACK 0x20
-#define PUBLISH 0x30
-#define PUBACK 0x40
-#define PUBREC 0x50
-#define PUBREL 0x60
-#define PUBCOMP 0x70
-#define SUBSCRIBE 0x80
-#define SUBACK 0x90
-#define UNSUBSCRIBE 0xA0
-#define UNSUBACK 0xB0
-#define PINGREQ 0xC0
-#define PINGRESP 0xD0
-#define DISCONNECT 0xE0
+constexpr quint8 CONNECT     = 0x10;
+constexpr quint8 CONNACK     = 0x20;
+constexpr quint8 PUBLISH     = 0x30;
+constexpr quint8 PUBACK      = 0x40;
+constexpr quint8 PUBREC      = 0x50;
+constexpr quint8 PUBREL      = 0x60;
+constexpr quint8 PUBCOMP     = 0x70;
+constexpr quint8 SUBSCRIBE   = 0x80;
+constexpr quint8 SUBACK      = 0x90;
+constexpr quint8 UNSUBSCRIBE = 0xA0;
+constexpr quint8 UNSUBACK    = 0xB0;
+constexpr quint8 PINGREQ     = 0xC0;
+constexpr quint8 PINGRESP    = 0xD0;
+constexpr quint8 DISCONNECT  = 0xE0;
 
 constexpr inline quint8 LSB(quint16 A) { return quint8(A & 0x00FF); }
 constexpr inline quint8 MSB(quint16 A) { return quint8((A & 0xFF00) >> 8); }

--- a/src/mqtt/qmqtt_message.h
+++ b/src/mqtt/qmqtt_message.h
@@ -63,7 +63,7 @@ public:
     { return !operator==(other); }
 
     inline void swap(Message &other) Q_DECL_NOTHROW
-    { qSwap(d, other.d); }
+    { d.swap(other.d); }
 
     quint16 id() const;
     void setId(const quint16 id);

--- a/src/mqtt/qmqtt_network.cpp
+++ b/src/mqtt/qmqtt_network.cpp
@@ -34,8 +34,11 @@
 #include "qmqtt_socket_p.h"
 #include "qmqtt_ssl_socket_p.h"
 #include "qmqtt_timer_p.h"
-#include "qmqtt_websocket_p.h"
 #include "qmqtt_frame.h"
+
+#ifdef QT_WEBSOCKETS_LIB
+#include "qmqtt_websocket_p.h"
+#endif
 
 #include <QDataStream>
 

--- a/src/mqtt/qmqtt_network_p.h
+++ b/src/mqtt/qmqtt_network_p.h
@@ -59,9 +59,9 @@ class Network : public NetworkInterface
     Q_OBJECT
 
 public:
-    Network(QObject* parent = nullptr);
+    explicit Network(QObject* parent = nullptr);
 #ifndef QT_NO_SSL
-    Network(const QSslConfiguration& config, QObject* parent = nullptr);
+    explicit Network(const QSslConfiguration& config, QObject* parent = nullptr);
 #endif // QT_NO_SSL
 #ifdef QT_WEBSOCKETS_LIB
 #ifndef QT_NO_SSL
@@ -78,25 +78,25 @@ public:
             QObject* parent = nullptr);
     ~Network();
 
-    void sendFrame(const Frame &frame);
-    bool isConnectedToHost() const;
-    bool autoReconnect() const;
-    void setAutoReconnect(const bool autoReconnect);
-    QAbstractSocket::SocketState state() const;
-    int autoReconnectInterval() const;
-    void setAutoReconnectInterval(const int autoReconnectInterval);
+    void sendFrame(const Frame &frame) override;
+    bool isConnectedToHost() const override;
+    bool autoReconnect() const override;
+    void setAutoReconnect(const bool autoReconnect) override;
+    QAbstractSocket::SocketState state() const override;
+    int autoReconnectInterval() const override;
+    void setAutoReconnectInterval(const int autoReconnectInterval) override;
 #ifndef QT_NO_SSL
-    void ignoreSslErrors(const QList<QSslError>& errors);
-    QSslConfiguration sslConfiguration() const;
-    void setSslConfiguration(const QSslConfiguration& config);
+    void ignoreSslErrors(const QList<QSslError>& errors) override;
+    QSslConfiguration sslConfiguration() const override;
+    void setSslConfiguration(const QSslConfiguration& config) override;
 #endif // QT_NO_SSL
 
 public Q_SLOTS:
-    void connectToHost(const QHostAddress& host, const quint16 port);
-    void connectToHost(const QString& hostName, const quint16 port);
-    void disconnectFromHost();
+    void connectToHost(const QHostAddress& host, const quint16 port) override;
+    void connectToHost(const QString& hostName, const quint16 port) override;
+    void disconnectFromHost() override;
 #ifndef QT_NO_SSL
-    void ignoreSslErrors();
+    void ignoreSslErrors() override;
 #endif // QT_NO_SSL
 
 protected Q_SLOTS:

--- a/src/mqtt/qmqtt_routedmessage.h
+++ b/src/mqtt/qmqtt_routedmessage.h
@@ -48,7 +48,7 @@ class Q_MQTT_EXPORT RoutedMessage
 public:
     inline RoutedMessage()
     {}
-    inline RoutedMessage(const Message &message)
+    inline explicit RoutedMessage(const Message &message)
         : _message(message)
     {}
 

--- a/src/mqtt/qmqtt_socket.cpp
+++ b/src/mqtt/qmqtt_socket.cpp
@@ -38,9 +38,9 @@ QMQTT::Socket::Socket(QObject* parent)
     : SocketInterface(parent)
     , _socket(new QTcpSocket(this))
 {
-    connect(_socket.data(), &QTcpSocket::connected,    this, &SocketInterface::connected);
-    connect(_socket.data(), &QTcpSocket::disconnected, this, &SocketInterface::disconnected);
-    connect(_socket.data(),
+    connect(_socket.get(), &QTcpSocket::connected,    this, &SocketInterface::connected);
+    connect(_socket.get(), &QTcpSocket::disconnected, this, &SocketInterface::disconnected);
+    connect(_socket.get(),
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             static_cast<void (QTcpSocket::*)(QAbstractSocket::SocketError)>(&QTcpSocket::errorOccurred),
 #else
@@ -56,7 +56,7 @@ QMQTT::Socket::~Socket()
 
 QIODevice *QMQTT::Socket::ioDevice()
 {
-    return _socket.data();
+    return _socket.get();
 }
 
 void QMQTT::Socket::connectToHost(const QHostAddress& address, quint16 port)

--- a/src/mqtt/qmqtt_socket_p.h
+++ b/src/mqtt/qmqtt_socket_p.h
@@ -38,7 +38,7 @@
 #include <QHostAddress>
 #include <QString>
 #include <QAbstractSocket>
-#include <QScopedPointer>
+#include <memory>
 
 QT_FORWARD_DECLARE_CLASS(QIODevice)
 QT_FORWARD_DECLARE_CLASS(QTcpSocket)
@@ -51,17 +51,17 @@ class Socket : public SocketInterface
     Q_OBJECT
 public:
     explicit Socket(QObject* parent = nullptr);
-    virtual	~Socket();
+    ~Socket() override;
 
-    virtual QIODevice *ioDevice();
-    void connectToHost(const QHostAddress& address, quint16 port);
-    void connectToHost(const QString& hostName, quint16 port);
-    void disconnectFromHost();
-    QAbstractSocket::SocketState state() const;
-    QAbstractSocket::SocketError error() const;
+    QIODevice *ioDevice() override;
+    void connectToHost(const QHostAddress& address, quint16 port) override;
+    void connectToHost(const QString& hostName, quint16 port) override;
+    void disconnectFromHost() override;
+    QAbstractSocket::SocketState state() const override;
+    QAbstractSocket::SocketError error() const override;
 
 protected:
-    QScopedPointer<QTcpSocket> _socket;
+    std::unique_ptr<QTcpSocket> _socket;
 };
 
 }

--- a/src/mqtt/qmqtt_ssl_socket.cpp
+++ b/src/mqtt/qmqtt_ssl_socket.cpp
@@ -43,9 +43,9 @@ QMQTT::SslSocket::SslSocket(const QSslConfiguration& config, QObject* parent)
     , _socket(new QSslSocket(this))
 {
     _socket->setSslConfiguration(config);
-    connect(_socket.data(), &QSslSocket::encrypted,    this, &SocketInterface::connected);
-    connect(_socket.data(), &QSslSocket::disconnected, this, &SocketInterface::disconnected);
-    connect(_socket.data(),
+    connect(_socket.get(), &QSslSocket::encrypted,    this, &SocketInterface::connected);
+    connect(_socket.get(), &QSslSocket::disconnected, this, &SocketInterface::disconnected);
+    connect(_socket.get(),
 #if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
             static_cast<void (QSslSocket::*)(QAbstractSocket::SocketError)>(&QSslSocket::errorOccurred),
 #else
@@ -53,7 +53,7 @@ QMQTT::SslSocket::SslSocket(const QSslConfiguration& config, QObject* parent)
 #endif
             this,
             static_cast<void (SocketInterface::*)(QAbstractSocket::SocketError)>(&SocketInterface::error));
-    connect(_socket.data(),
+    connect(_socket.get(),
             static_cast<void (QSslSocket::*)(const QList<QSslError>&)>(&QSslSocket::sslErrors),
             this,
             &SslSocket::sslErrors);
@@ -65,7 +65,7 @@ QMQTT::SslSocket::~SslSocket()
 
 QIODevice *QMQTT::SslSocket::ioDevice()
 {
-    return _socket.data();
+    return _socket.get();
 }
 
 void QMQTT::SslSocket::connectToHost(const QHostAddress& address, quint16 port)

--- a/src/mqtt/qmqtt_ssl_socket_p.h
+++ b/src/mqtt/qmqtt_ssl_socket_p.h
@@ -41,7 +41,7 @@
 #include <QHostAddress>
 #include <QString>
 #include <QList>
-#include <QScopedPointer>
+#include <memory>
 
 QT_FORWARD_DECLARE_CLASS(QSslSocket)
 QT_FORWARD_DECLARE_CLASS(QSslError)
@@ -55,21 +55,21 @@ class SslSocket : public SocketInterface
     Q_OBJECT
 public:
     explicit SslSocket(const QSslConfiguration& config, QObject* parent = nullptr);
-    virtual ~SslSocket();
+    ~SslSocket() override;
 
-    virtual QIODevice *ioDevice();
-    void connectToHost(const QHostAddress& address, quint16 port);
-    void connectToHost(const QString& hostName, quint16 port);
-    void disconnectFromHost();
-    QAbstractSocket::SocketState state() const;
-    QAbstractSocket::SocketError error() const;
-    void ignoreSslErrors(const QList<QSslError>& errors);
-    void ignoreSslErrors();
-    QSslConfiguration sslConfiguration() const;
-    void setSslConfiguration(const QSslConfiguration& config);
+    QIODevice *ioDevice() override;
+    void connectToHost(const QHostAddress& address, quint16 port) override;
+    void connectToHost(const QString& hostName, quint16 port) override;
+    void disconnectFromHost() override;
+    QAbstractSocket::SocketState state() const override;
+    QAbstractSocket::SocketError error() const override;
+    void ignoreSslErrors(const QList<QSslError>& errors) override;
+    void ignoreSslErrors() override;
+    QSslConfiguration sslConfiguration() const override;
+    void setSslConfiguration(const QSslConfiguration& config) override;
 
 protected:
-    QScopedPointer<QSslSocket> _socket;
+    std::unique_ptr<QSslSocket> _socket;
 };
 
 }

--- a/src/mqtt/qmqtt_timer_p.h
+++ b/src/mqtt/qmqtt_timer_p.h
@@ -44,14 +44,14 @@ class Timer : public TimerInterface
     Q_OBJECT
 public:
     explicit Timer(QObject *parent = nullptr);
-    virtual ~Timer();
+    ~Timer() override;
 
-    bool isSingleShot() const;
-    void setSingleShot(bool singleShot);
-    int interval() const;
-    void setInterval(int msec);
-    void start();
-    void stop();
+    bool isSingleShot() const override;
+    void setSingleShot(bool singleShot) override;
+    int interval() const override;
+    void setInterval(int msec) override;
+    void start() override;
+    void stop() override;
 
 protected:
     QTimer _timer;

--- a/src/mqtt/qmqtt_websocket_p.h
+++ b/src/mqtt/qmqtt_websocket_p.h
@@ -69,23 +69,23 @@ public:
               QWebSocketProtocol::Version version,
               QObject* parent = nullptr);
 
-    virtual ~WebSocket();
+    ~WebSocket() override;
 
-    QIODevice *ioDevice()
+    QIODevice *ioDevice() override
     {
         return _ioDevice;
     }
 
-    void connectToHost(const QHostAddress& address, quint16 port);
-    void connectToHost(const QString& hostName, quint16 port);
-    void disconnectFromHost();
-    QAbstractSocket::SocketState state() const;
-    QAbstractSocket::SocketError error() const;
+    void connectToHost(const QHostAddress& address, quint16 port) override;
+    void connectToHost(const QString& hostName, quint16 port) override;
+    void disconnectFromHost() override;
+    QAbstractSocket::SocketState state() const override;
+    QAbstractSocket::SocketError error() const override;
 #ifndef QT_NO_SSL
-    void ignoreSslErrors(const QList<QSslError>& errors);
-    void ignoreSslErrors();
-    QSslConfiguration sslConfiguration() const;
-    void setSslConfiguration(const QSslConfiguration& config);
+    void ignoreSslErrors(const QList<QSslError>& errors) override;
+    void ignoreSslErrors() override;
+    QSslConfiguration sslConfiguration() const override;
+    void setSslConfiguration(const QSslConfiguration& config) override;
 #endif // QT_NO_SSL
 
 private:

--- a/src/mqtt/qmqtt_websocketiodevice.cpp
+++ b/src/mqtt/qmqtt_websocketiodevice.cpp
@@ -21,7 +21,7 @@ bool QMQTT::WebSocketIODevice::connectToHost(const QNetworkRequest &request)
 
 qint64 QMQTT::WebSocketIODevice::bytesAvailable() const
 {
-    return _buffer.count();
+    return _buffer.size();
 }
 
 void QMQTT::WebSocketIODevice::binaryMessageReceived(const QByteArray &frame)

--- a/src/mqtt/qmqtt_websocketiodevice_p.h
+++ b/src/mqtt/qmqtt_websocketiodevice_p.h
@@ -52,12 +52,12 @@ public:
 
     bool connectToHost(const QNetworkRequest &request);
 
-    virtual qint64 bytesAvailable() const;
+    qint64 bytesAvailable() const override;
 
 protected:
-    virtual qint64 readData(char *data, qint64 maxSize);
+    qint64 readData(char *data, qint64 maxSize) override;
 
-    virtual qint64 writeData(const char *data, qint64 maxSize);
+    qint64 writeData(const char *data, qint64 maxSize) override;
 
 private Q_SLOTS:
     void binaryMessageReceived(const QByteArray &frame);


### PR DESCRIPTION
- Replaced QScopedPointer with std::unique_ptr (and updated .data() calls to .get()).
- Added override specifiers to methods overriding virtual interfaces.
- Added explicit specifiers to constructors with a single mandatory parameter to prevent implicit conversions.
- Replaced #define macros used for MQTT protocol constants and string literals with type-safe constexpr.
- Replaced the foreach macro with modern range-based for loops.
- Fixed cppcheck warnings: using constructor initialization lists, resolving variable shadowing, reducing unnecessary copies, and localizing variable scope.
- Replaced qSwap() with the swap() method of the used object.
- Fixed conditional inclusion of WebSocket headers when building without WebSocket support.